### PR TITLE
Add the constant pi and related values

### DIFF
--- a/src/float.ml
+++ b/src/float.ml
@@ -198,6 +198,12 @@ let zero = 0.
 let one = 1.
 let minus_one = -1.
 
+let pi = 3.14159265358979323846264338328
+let pi_2 = 1.57079632679489661923132169164
+let pi_4 = 0.78539816339744830961566084582
+let sqrt_pi = 1.77245385090551602729816748334
+let inv_pi = 0.31830988618379067153776752675
+
 (* The bits of INRIA's [Pervasives] that we just want to expose in
    [Float]. Most are already deprecated in [Pervasives], and
    eventually all of them should be. *)

--- a/src/float.ml
+++ b/src/float.ml
@@ -198,11 +198,11 @@ let zero = 0.
 let one = 1.
 let minus_one = -1.
 
-let pi = 3.14159265358979323846264338328
-let pi_2 = 1.57079632679489661923132169164
-let pi_4 = 0.78539816339744830961566084582
-let sqrt_pi = 1.77245385090551602729816748334
-let inv_pi = 0.31830988618379067153776752675
+let pi = 0x3.243f6a8885a308d313198a2e037073
+let pi_2 = 0x3.243F6A8885A308D31319p-1
+let pi_4 = 0x3.243f6a8885a308d313198a2e037073p-2
+let inv_pi = 0x0.517cc1b727220a94fe13abe8fa9a6e
+let sqrt_pi = 0x1.c5bf891b4ef6aa79c3b0520d5db938
 
 (* The bits of INRIA's [Pervasives] that we just want to expose in
    [Float]. Most are already deprecated in [Pervasives], and

--- a/src/float.ml
+++ b/src/float.ml
@@ -200,6 +200,8 @@ let minus_one = -1.
 
 let pi = 0x3.243f6a8885a308d313198a2e037073
 let sqrt_pi = 0x1.c5bf891b4ef6aa79c3b0520d5db938
+let sqrt_2pi = 0x2.81b263fec4e0b2caf9483f5ce459dc
+let euler = 0x0.93C467E37DB0C7A4D1BE3F810152CB
 
 (* The bits of INRIA's [Pervasives] that we just want to expose in
    [Float]. Most are already deprecated in [Pervasives], and

--- a/src/float.ml
+++ b/src/float.ml
@@ -199,9 +199,6 @@ let one = 1.
 let minus_one = -1.
 
 let pi = 0x3.243f6a8885a308d313198a2e037073
-let pi_2 = 0x3.243F6A8885A308D31319p-1
-let pi_4 = 0x3.243f6a8885a308d313198a2e037073p-2
-let inv_pi = 0x0.517cc1b727220a94fe13abe8fa9a6e
 let sqrt_pi = 0x1.c5bf891b4ef6aa79c3b0520d5db938
 
 (* The bits of INRIA's [Pervasives] that we just want to expose in

--- a/src/float.mli
+++ b/src/float.mli
@@ -43,10 +43,7 @@ val one : t
 val minus_one : t
 
 val pi : t      (** The constant pi. *)
-val pi_2 : t    (** The constant pi/2. *)
-val pi_4 : t    (** The constant pi/4. *)
 val sqrt_pi : t (** The constant sqrt(pi). *)
-val inv_pi : t  (** The constant 1/pi. *)
 
 (** The difference between 1.0 and the smallest exactly representable floating-point
     number greater than 1.0.  That is:

--- a/src/float.mli
+++ b/src/float.mli
@@ -42,6 +42,12 @@ val zero : t
 val one : t
 val minus_one : t
 
+val pi : t      (** The constant pi. *)
+val pi_2 : t    (** The constant pi/2. *)
+val pi_4 : t    (** The constant pi/4. *)
+val sqrt_pi : t (** The constant sqrt(pi). *)
+val inv_pi : t  (** The constant 1/pi. *)
+
 (** The difference between 1.0 and the smallest exactly representable floating-point
     number greater than 1.0.  That is:
 

--- a/src/float.mli
+++ b/src/float.mli
@@ -42,8 +42,10 @@ val zero : t
 val one : t
 val minus_one : t
 
-val pi : t      (** The constant pi. *)
-val sqrt_pi : t (** The constant sqrt(pi). *)
+val pi : t       (** The constant pi. *)
+val sqrt_pi : t  (** The constant sqrt(pi). *)
+val sqrt_2pi : t (** The constant sqrt(2 * pi). *)
+val euler : t    (** Euler-Mascheroni constant (γ). *)
 
 (** The difference between 1.0 and the smallest exactly representable floating-point
     number greater than 1.0.  That is:


### PR DESCRIPTION
The addition of the constant to Pervasives has been requested several
times but it is better that these constants do not clutter the default
namespace by being in the Float module.

https://caml.inria.fr/mantis/view.php?id=4170
https://caml.inria.fr/mantis/view.php?id=5173