### PR TITLE
Add function `find_multi` to Map and Hashtbl

### DIFF
--- a/src/hashtbl.ml
+++ b/src/hashtbl.ml
@@ -432,6 +432,11 @@ let remove_multi t key =
   | Some [] | Some [_] -> remove t key
   | Some (_ :: tl) -> replace t ~key ~data:tl
 
+let find_multi t key =
+  match find t key with
+  | None -> []
+  | Some l -> l
+
 let create_mapped ?growth_allowed ?size ~hashable ~get_key ~get_data rows =
   let size = match size with Some s -> s | None -> List.length rows in
   let res = create ?growth_allowed ~hashable ~size () in
@@ -685,6 +690,7 @@ module Accessors = struct
   let update              = update
   let add_multi           = add_multi
   let remove_multi        = remove_multi
+  let find_multi          = find_multi
   let mem                 = mem
   let iter_keys           = iter_keys
   let iter                = iter

--- a/src/hashtbl_intf.ml
+++ b/src/hashtbl_intf.ml
@@ -107,6 +107,10 @@ module type Accessors = sig
       removed. *)
   val remove_multi : ('a, _ list) t -> 'a key -> unit
 
+  (** [find_multi t key] returns the empty list if [key] is not present in the table,
+      returns [t]'s values for [key] otherwise *)
+  val find_multi : ('a, 'b list) t -> 'a key -> 'b list
+
   (** [map t f] returns new table with bound values replaced by
       [f] applied to the bound values *)
   val map : ('a, 'b) t -> f:('b -> 'c) -> ('a, 'c) t

--- a/src/map.ml
+++ b/src/map.ml
@@ -285,6 +285,12 @@ module Tree0 = struct
     add ~length ~key ~data t ~compare_key
   ;;
 
+  let find_multi t x ~compare_key =
+    match find t x ~compare_key with
+    | None -> []
+    | Some l -> l
+  ;;
+
   let find_exn t x ~compare_key =
     match find t x ~compare_key with
     | Some data -> data
@@ -1111,6 +1117,7 @@ module Accessors = struct
   let remove_multi t key =
     like t (Tree0.remove_multi t.tree ~length:t.length key ~compare_key:(compare_key t))
   ;;
+  let find_multi t key = Tree0.find_multi t.tree key ~compare_key:(compare_key t)
   let change t key ~f =
     like t (Tree0.change t.tree key ~f ~length:t.length ~compare_key:(compare_key t))
   ;;
@@ -1294,6 +1301,9 @@ module Tree = struct
   let remove_multi ~comparator t key =
     Tree0.remove_multi t key ~length:0 ~compare_key:comparator.Comparator.compare
     |> fst
+  ;;
+  let find_multi ~comparator t key =
+    Tree0.find_multi t key ~compare_key:comparator.Comparator.compare
   ;;
   let change ~comparator t key ~f =
     fst (Tree0.change t key ~f ~length:0 ~compare_key:comparator.Comparator.compare)

--- a/src/map.mli
+++ b/src/map.mli
@@ -110,6 +110,12 @@ val remove_multi
   -> 'k
   -> ('k, 'v list, 'cmp) t
 
+(** returns the value bound to the given key, or the empty list if there is none. *)
+val find_multi
+  : ('k, 'v list, 'cmp) t
+  -> 'k
+  -> 'v list
+
 (** [change t key ~f] returns a new map [m] that is the same as [t] on all keys except for
     [key], and whose value for [key] is defined by [f], i.e. [find m key = f (find t
     key)]. *)

--- a/src/map_intf.ml
+++ b/src/map_intf.ml
@@ -185,6 +185,12 @@ module type Accessors_generic = sig
        -> ('k, 'v list, 'cmp) t
       ) options
 
+  val find_multi
+    : ('k, 'cmp,
+       ('k, 'v list, 'cmp) t
+       -> 'k key -> 'v list
+      ) options
+
   val change
     : ('k, 'cmp,
        ('k, 'v, 'cmp) t
@@ -456,6 +462,7 @@ module type Accessors1 = sig
   val add            : 'a t -> key:key -> data:'a -> 'a t
   val add_multi      : 'a list t -> key:key -> data:'a -> 'a list t
   val remove_multi   : 'a list t -> key -> 'a list t
+  val find_multi     : 'a list t -> key -> 'a list
   val change         : 'a t -> key -> f:('a option -> 'a option) -> 'a t
   val update         : 'a t -> key -> f:('a option -> 'a) -> 'a t
   val find           : 'a t -> key -> 'a option
@@ -575,6 +582,7 @@ module type Accessors2 = sig
   val add            : ('a, 'b) t -> key:'a -> data:'b -> ('a, 'b) t
   val add_multi      : ('a, 'b list) t -> key:'a -> data:'b -> ('a, 'b list) t
   val remove_multi   : ('a, 'b list) t -> 'a -> ('a, 'b list) t
+  val find_multi     : ('a, 'b list) t -> 'a -> 'b list
   val change         : ('a, 'b) t -> 'a -> f:('b option -> 'b option) -> ('a, 'b) t
   val update         : ('a, 'b) t -> 'a -> f:('b option -> 'b) -> ('a, 'b) t
   val find           : ('a, 'b) t -> 'a -> 'b option
@@ -690,6 +698,7 @@ module type Accessors3 = sig
   val add            : ('a, 'b,      'cmp) t -> key:'a -> data:'b -> ('a, 'b     , 'cmp) t
   val add_multi      : ('a, 'b list, 'cmp) t -> key:'a -> data:'b -> ('a, 'b list, 'cmp) t
   val remove_multi   : ('a, 'b list, 'cmp) t -> 'a -> ('a, 'b list, 'cmp) t
+  val find_multi     : ('a, 'b list, 'cmp) t -> 'a -> 'b list
   val change         : ('a, 'b, 'cmp) t -> 'a -> f:('b option -> 'b option) -> ('a, 'b, 'cmp) t
   val update         : ('a, 'b, 'cmp) t -> 'a -> f:('b option -> 'b) -> ('a, 'b, 'cmp) t
   val find           : ('a, 'b, 'cmp) t -> 'a -> 'b option
@@ -819,6 +828,9 @@ module type Accessors3_with_comparator = sig
   val remove_multi
     :  comparator:('a, 'cmp) Comparator.t
     -> ('a, 'b list, 'cmp) t -> 'a -> ('a, 'b list, 'cmp) t
+  val find_multi
+    : comparator:('a, 'cmp) Comparator.t
+    -> ('a, 'b list, 'cmp) t -> 'a -> 'b list
   val change
     :  comparator:('a, 'cmp) Comparator.t
     -> ('a, 'b, 'cmp) t -> 'a -> f:('b option -> 'b option) -> ('a, 'b, 'cmp) t


### PR DESCRIPTION
Map and Hashtbl already contain functions `add_multi` and `remove_multi` to deal
with maps and hashtables when the data type of the values is a list.

`find_multi table key` returns the value associated to `key` if there is some,
or the empty list. `find_multi` raises no exception and
```   
find_multi : ('key, 'a list) t -> 'key -> 'a list
```

It really looks like a missing function from the existing interface.