### PR TITLE
Fix Map.find documentation comment describing Map.find_exn

### DIFF
--- a/src/map_intf.ml
+++ b/src/map_intf.ml
@@ -1455,8 +1455,7 @@ module type Map = sig
     -> f:('v option -> 'v)
     -> ('k, 'v, 'cmp) t
 
-  (** Returns the value bound to the given key, raising [Caml.Not_found] of [Not_found_s]
-      if none exists. *)
+  (** Returns [Some value] bound to the given key, or [None] if none exists. *)
   val find     : ('k, 'v, 'cmp) t -> 'k -> 'v option
   val find_exn : ('k, 'v, 'cmp) t -> 'k -> 'v
 


### PR DESCRIPTION
The comment on `Map.find` was describing `Map.find_exn` instead. I chose a new wording based on some of the other comments in that module. I left `find_exn` undocumented since most of the "_exn" functions in the module are like that.