### PR TITLE
Add List.partition_result

### DIFF
--- a/src/list.ml
+++ b/src/list.ml
@@ -769,6 +769,14 @@ let partition_tf t ~f =
   partition_map t ~f
 ;;
 
+let partition_result t =
+  let f x =
+    match x with
+    | Ok v -> `Fst v
+    | Error e -> `Snd e
+  in
+  partition_map t ~f
+
 module Assoc = struct
 
   type ('a, 'b) t = ('a * 'b) list [@@deriving_inline sexp]

--- a/src/list.mli
+++ b/src/list.mli
@@ -130,6 +130,12 @@ val partition3_map
     is (trues, falses). *)
 val partition_tf : 'a t -> f:('a -> bool) -> 'a t * 'a t
 
+(** [partition_result l] returns a pair of lists [(l1, l2)], where [l1] is the
+    list of all [Ok] elements in [l] and [l2] is the list of all [Error]
+    elements.
+    The order of elements in the input list is preserved. *)
+val partition_result : ('ok, 'error) Result.t t -> 'ok t * 'error t
+
 (** [split_n \[e1; ...; em\] n] is [(\[e1; ...; en\], \[en+1; ...; em\])].
 
     - If [n > m], [(\[e1; ...; em\], \[\])] is returned.


### PR DESCRIPTION
This is a helper function to partition a list of ('ok, 'error') Result.t
into a list of 'ok and a list of 'error.