### PR TITLE
Add Array.of_list_mapi and .of_list_rev_mapi

### DIFF
--- a/src/array.ml
+++ b/src/array.ml
@@ -376,8 +376,23 @@ let of_list_map xs ~f =
       | hd::tl -> unsafe_set a i (f hd); fill (i+1) tl in
     fill 1 tl
 
+let of_list_mapi xs ~f =
+  match xs with
+  | [] -> [||]
+  | hd::tl ->
+    let a = create ~len:(1 + List.length tl) (f 0 hd) in
+    let rec fill i = function
+      | [] -> a
+      | hd::tl -> unsafe_set a i (f i hd); fill (i+1) tl in
+    fill 1 tl
+
 let of_list_rev_map xs ~f =
   let t = of_list_map xs ~f in
+  rev_inplace t;
+  t
+
+let of_list_rev_mapi xs ~f =
+  let t = of_list_mapi xs ~f in
   rev_inplace t;
   t
 

--- a/src/array.mli
+++ b/src/array.mli
@@ -215,8 +215,14 @@ val of_list_rev : 'a list -> 'a t
 (** [of_list_map l ~f] is the same as [of_list (List.map l ~f)]. *)
 val of_list_map : 'a list -> f:('a -> 'b) -> 'b t
 
+(** [of_list_map l ~f] is the same as [of_list (List.mapi l ~f)]. *)
+val of_list_mapi : 'a list -> f:(int -> 'a -> 'b) -> 'b t
+
 (** [of_list_rev_map l ~f] is the same as [rev_inplace (of_list_map l ~f)]. *)
 val of_list_rev_map : 'a list -> f:('a -> 'b) -> 'b t
+
+(** [of_list_rev_mapi l ~f] is the same as [rev_inplace (of_list_mapi l ~f)]. *)
+val of_list_rev_mapi : 'a list -> f:(int -> 'a -> 'b) -> 'b t
 
 (** [replace t i ~f] = [t.(i) <- f (t.(i))]. *)
 val replace : 'a t -> int -> f:('a -> 'a) -> unit


### PR DESCRIPTION
I ran into a situation where I wanted `of_list_mapi`.

So, without any particular reflection about proliferation of infrequently-used *_mapi variants... I present this pull request.