### PR TITLE
Give a name to drop and take parameters

### DIFF
--- a/src/sequence.ml
+++ b/src/sequence.ml
@@ -818,21 +818,21 @@ let sub s ~pos ~len =
                   | Yield(a, s) when i >= pos -> Yield (a,(i + 1, s))
                   | Yield(_, s) -> Skip(i + 1, s)))
 
-let take s len =
-  if len < 0 then failwith "Sequence.take";
+let take s ~n =
+  if n < 0 then failwith "Sequence.take";
   match s with
   | Sequence(s, next) ->
     Sequence((0,s),
              (fun (i, s) ->
-                if i >= len then Done
+                if i >= n then Done
                 else
                   match next s with
                   | Done -> Done
                   | Skip s -> Skip (i, s)
                   | Yield(a, s) -> Yield (a,(i + 1, s))))
 
-let drop s len =
-  if len < 0 then failwith "Sequence.drop";
+let drop s ~n =
+  if n < 0 then failwith "Sequence.drop";
   match s with
   | Sequence(s, next) ->
     Sequence((0,s),
@@ -840,7 +840,7 @@ let drop s len =
                 match next s with
                 | Done -> Done
                 | Skip s -> Skip (i, s)
-                | Yield(a, s) when i >= len -> Yield (a,(i + 1, s))
+                | Yield(a, s) when i >= n -> Yield (a,(i + 1, s))
                 | Yield(_, s) -> Skip (i+1, s)))
 
 let take_while s ~f =
@@ -988,17 +988,17 @@ let memoize (type a) (Sequence (s, next)) =
   in
   Sequence (memoize s, (fun (M.T l) -> Lazy.force l))
 
-let drop_eagerly s len =
-  let rec loop i ~len s next =
-    if i >= len then Sequence(s, next)
+let drop_eagerly s ~n =
+  let rec loop i ~n s next =
+    if i >= n then Sequence(s, next)
     else
       match next s with
       | Done -> empty
-      | Skip s -> loop i ~len s next
-      | Yield(_,s) -> loop (i+1) ~len s  next
+      | Skip s -> loop i ~n s next
+      | Yield(_,s) -> loop (i+1) ~n s  next
   in
   match s with
-  | Sequence(s, next) -> loop 0 ~len s next
+  | Sequence(s, next) -> loop 0 ~n s next
 
 let drop_while_option (Sequence (s, next)) ~f =
   let rec loop s =

--- a/src/sequence.mli
+++ b/src/sequence.mli
@@ -271,18 +271,18 @@ val filter_opt : 'a option t -> 'a t
     the length of the sequence. *)
 val sub : 'a t -> pos:int -> len:int -> 'a t
 
-(** [take t n] produces the first [n] elements of [t]. *)
-val take : 'a t -> int -> 'a t
+(** [take t ~n] produces the first [n] elements of [t]. *)
+val take : 'a t -> n:int -> 'a t
 
-(** [drop t n] produces all elements of [t] except the first [n] elements.  If there are
+(** [drop t ~n] produces all elements of [t] except the first [n] elements.  If there are
     fewer than [n] elements in [t], there is no error; the resulting sequence simply
     produces no elements.  Usually you will probably want to use [drop_eagerly] because it
     can be significantly cheaper. *)
-val drop : 'a t -> int -> 'a t
+val drop : 'a t -> n:int -> 'a t
 
-(** [drop_eagerly t n] immediately consumes the first [n] elements of [t] and returns the
+(** [drop_eagerly t ~n] immediately consumes the first [n] elements of [t] and returns the
     unevaluated tail of [t]. *)
-val drop_eagerly : 'a t -> int -> 'a t
+val drop_eagerly : 'a t -> n:int -> 'a t
 
 (** [take_while t ~f] produces the longest prefix of [t] for which [f] applied to each
     element is [true]. *)
@@ -324,8 +324,8 @@ val shift_right : 'a t -> 'a -> 'a t
     latter O(n) work per element produced. *)
 val shift_right_with_list : 'a t -> 'a list -> 'a t
 
-(** [shift_left t n] is a synonym for [drop t n].*)
-val shift_left : 'a t -> int -> 'a t
+(** [shift_left t ~n] is a synonym for [drop t ~n].*)
+val shift_left : 'a t -> n:int -> 'a t
 
 module Infix : sig
   val ( @ ) : 'a t -> 'a t -> 'a t


### PR DESCRIPTION
Hi there,

While using `base`, I realized that it was sometimes inconvenient to work with sequences. Especially when doing things like:

    Sequence.repeat elem
      |> Fn.flip Sequence.take 50

I decided to add a name to the argument for the amount of elements being dropped or taken. This allows (IMHO) better code like:

    Sequence.repeat elem
      |> Sequence.take ~n:50