### PR TITLE
Add String.trim

### DIFF
--- a/src/string.mli
+++ b/src/string.mli
@@ -64,6 +64,12 @@ val concat : ?sep:t -> t list -> t
     conventions of OCaml. *)
 val escaped : t -> t
 
+(** Return a copy of the argument, without leading and trailing whitespace.
+    The characters regarded as whitespace are: [' '], ['\012'], '[\n]', '[\r]', and
+    '[\t]'. If there is neither leading nor trailing whitespace character in the
+    argument, return the original string itself, not a copy. *)
+val trim : t -> t
+
 val contains : ?pos:int -> ?len:int -> t -> char -> bool
 
 (** Operates on the whole string using the US-ASCII character set,

--- a/src/string0.ml
+++ b/src/string0.ml
@@ -47,6 +47,7 @@ let index_from_exn  = Caml.String.index_from
 let make            = Caml.String.make
 let rindex_exn      = Caml.String.rindex
 let rindex_from_exn = Caml.String.rindex_from
+let trim            = Caml.String.trim
 let sub             = Caml.String.sub
 let unsafe_blit     = Caml.String.unsafe_blit
 


### PR DESCRIPTION
This adds the String.trim function from the standard library.
https://caml.inria.fr/pub/docs/manual-ocaml/libref/String.html#VALtrim