### PR TITLE
Fix the generation of mpopcnt.sexp on Windows

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -30,7 +30,9 @@
    (with-stdout-to popcnt_test.c
     (echo
      "int main(int argc, char ** argv) { return __builtin_popcount(argc); }"))
-   (system
-    "%{cc} -mpopcnt -c popcnt_test.c 2> ${null} && echo '(-mpopcnt)' > %{targets} || echo '()' > %{targets}"))))
+   (with-stdout-to %{targets}
+    (progn (echo "(")
+    (system "%{cc} -mpopcnt -c popcnt_test.c 2> %{null} && echo -mpopcnt || true 2> %{null} || ver > %{null}")
+    (echo ")"))))))
 
 (ocamllex hex_lexer)


### PR DESCRIPTION
On Windows, the echo command will include the quotes passed to it, so echo '()' results in the literal string `'()'` being written to the file, which is obviously not valid. Removing the quotes results in
invalid bash as the brackets of course imply a subshell.

The solution is to assume that echo will never gain a `-m` parameter which means that `echo -mpopcnt` should work correctly on both platforms. The generation is converted to use `(progn ...)` and add the
brackets from the jbuild file instead of the shell.