### PR TITLE
Add support for OCaml 4.10

### DIFF
--- a/src/exn_stubs.c
+++ b/src/exn_stubs.c
@@ -1,6 +1,6 @@
+#define CAML_INTERNALS
 #include <caml/mlvalues.h>
-
-extern int caml_backtrace_pos;
+#include <caml/backtrace.h>
 
 CAMLprim value Base_clear_caml_backtrace_pos () {
   caml_backtrace_pos = 0;


### PR DESCRIPTION
With https://github.com/ocaml/ocaml/pull/9253 the OCaml compiler team decided to move back the `Caml_state` compatibility macros to the files they were defined in originally. So per @Octachron's recommendation here is a slightly simpler patch from the one you already had ready to add support for OCaml 4.10 in base.