### PR TITLE
docs(list.mli): add example for map2

### DIFF
--- a/src/list.mli
+++ b/src/list.mli
@@ -226,6 +226,14 @@ val concat_mapi : 'a t -> f:(int -> 'a -> 'b t) -> 'b t
     version will raise if the two lists have different lengths. *)
 val map2_exn : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
 
+(**
+    Example:
+
+    {[
+      let summed_list =
+        match List.map2 [ 1; 2; 3 ] [ 4; 5; 6 ] ~f:(+) with
+        | List.Or_unequal_lengths.Ok l -> l
+        | List.Or_unequal_lengths.Unequal_lengths -> [] ]} *)
 val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t Or_unequal_lengths.t
 
 (** Analogous to [rev_map2]. *)


### PR DESCRIPTION
OCaml overall lacks softer documentation as called out in the [OCaml Documentation Open Thread](https://discuss.ocaml.org/t/ocaml-documentation-open-thread/1841/150). I'd be happy to add some examples as I go along and figure things out. My commit message follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style, I hope that is ok.

Signed-off-by: Robin Björklin <robin.bjorklin@gmail.com>