### PR TITLE
OCaml 4.12 support

### DIFF
--- a/compiler-stdlib/gen/gen.ml
+++ b/compiler-stdlib/gen/gen.ml
@@ -5,6 +5,7 @@ module Ocaml_version : sig
 
   val v407 : t
   val v408 : t
+  val v412 : t
   val current : t
   val compare : t -> t -> int
 end = struct
@@ -26,6 +27,7 @@ end = struct
 
   let v407 = parse "4.07"
   let v408 = parse "4.08"
+  let v412 = parse "4.12"
   let current = parse Sys.ocaml_version
 
   let compare ((a1, b1) : t) ((a2, b2) : t) =
@@ -80,6 +82,10 @@ let () =
     pr "module Result = struct end";
     pr "module Unit   = struct end";
     pr "module Fun    = struct end");
+  if Ocaml_version.(compare current v412) < 0
+  then (
+    pr "module Atomic = struct end";
+    pr "module Either = struct end");
   pr "";
   pr "exception Not_found = Not_found"
 ;;

--- a/src/base.ml
+++ b/src/base.ml
@@ -39,10 +39,12 @@ include (
   end
   (* Modules defined in Base *)
   with module Array := Shadow_stdlib.Array
+  with module Atomic := Shadow_stdlib.Atomic
   with module Bool := Shadow_stdlib.Bool
   with module Buffer := Shadow_stdlib.Buffer
   with module Bytes := Shadow_stdlib.Bytes
   with module Char := Shadow_stdlib.Char
+  with module Either := Shadow_stdlib.Either
   with module Float := Shadow_stdlib.Float
   with module Hashtbl := Shadow_stdlib.Hashtbl
   with module Int := Shadow_stdlib.Int

--- a/src/import0.ml
+++ b/src/import0.ml
@@ -13,10 +13,12 @@ include (
   with type ('a, 'b, 'c, 'd, 'e, 'f) format6 := ('a, 'b, 'c, 'd, 'e, 'f) format6
   (* These modules are redefined in Base *)
   with module Array := Shadow_stdlib.Array
+  with module Atomic := Shadow_stdlib.Atomic
   with module Bool := Shadow_stdlib.Bool
   with module Buffer := Shadow_stdlib.Buffer
   with module Bytes := Shadow_stdlib.Bytes
   with module Char := Shadow_stdlib.Char
+  with module Either := Shadow_stdlib.Either
   with module Float := Shadow_stdlib.Float
   with module Hashtbl := Shadow_stdlib.Hashtbl
   with module Int := Shadow_stdlib.Int


### PR DESCRIPTION
Currently base does not compile with OCaml 4.12 as the new `Either` module interferes with `Base.Either` while compiling base.
Here is a PR targeted for the `v0.14` branch to get `base` to work with OCaml 4.12.