### PR TITLE
Make executable dependencies implicit

### DIFF
--- a/compiler-stdlib/src/dune
+++ b/compiler-stdlib/src/dune
@@ -1,4 +1,4 @@
 (library (name caml) (public_name base.caml) (preprocess no_preprocessing))
 
-(rule (targets caml.ml) (deps (:first_dep ../gen/gen.exe))
- (action (run %{first_dep} -ocaml-where %{ocaml_where} -o %{targets})))
+(rule (targets caml.ml)
+ (action (run ../gen/gen.exe -ocaml-where %{ocaml_where} -o %{targets})))

--- a/shadow-stdlib/src/dune
+++ b/shadow-stdlib/src/dune
@@ -2,7 +2,7 @@
  (libraries caml) (preprocess no_preprocessing))
 
 (rule (targets shadow_stdlib.mli)
- (deps (:first_dep ../gen/gen.exe) ../../compiler-stdlib/src/caml.cma)
+ (deps ../../compiler-stdlib/src/caml.cma)
  (action
-  (run %{first_dep} -caml-cmi ../../compiler-stdlib/src/.caml.objs/caml.cmi
+  (run ../gen/gen.exe -caml-cmi ../../compiler-stdlib/src/.caml.objs/caml.cmi
    ../../compiler-stdlib/src/.caml.objs/byte/caml.cmi -o %{targets})))


### PR DESCRIPTION
Explicit executable dependencies make dune fail in cross-compilation settings.
More info in ocaml/dune#3917.