### PR TITLE
Remove impossible match case in set

### DIFF
--- a/src/set.ml
+++ b/src/set.ml
@@ -212,7 +212,7 @@ module Tree0 = struct
     then (
       match r with
       | Empty -> assert false
-      | Leaf rv -> create (create l v Empty) rv Empty
+      | Leaf _ -> assert false (* because h(r)>h(l)+2 and h(leaf)=1 *)
       | Node (rl, rv, rr, _, _) ->
         if height rr >= height rl
         then create (create l v rl) rv rr


### PR DESCRIPTION
Hi. Thanks for the great library.
I found that the `Leaf` match case in `bal` function of `Set` module when the tree is right-skewed is impossible. It is ignored when the tree is left-skewed. So I suggest to ignore this case too.
Please review this change.
Thank you.