### PR TITLE
Expose Array.create_float from stdlib

### DIFF
--- a/src/array.mli
+++ b/src/array.mli
@@ -51,6 +51,10 @@ external unsafe_set : 'a t -> int -> 'a -> unit = "%array_unsafe_set"
     each element. *)
 val create : len:int -> 'a -> 'a t
 
+(** [create_float_uninitialized len] creates a float array of length [len] with uninitialized
+    elements. This can be significantly faster than using [create]. *)
+val create_float_uninitialized : int -> float t
+
 (** [init n ~f] creates an array of length [n] where the [i]th element (starting at zero)
     is initialized with [f i]. *)
 val init : int -> f:(int -> 'a) -> 'a t

--- a/src/array0.ml
+++ b/src/array0.ml
@@ -15,6 +15,8 @@ let invalid_argf = Printf.invalid_argf
 
 module Array = struct
   external create : int -> 'a -> 'a array = "caml_make_vect"
+  external create_float_uninitialized : int -> float array = "caml_make_float_vect"
+
   external get : 'a array -> int -> 'a = "%array_safe_get"
   external length : 'a array -> int = "%array_length"
   external set : 'a array -> int -> 'a -> unit = "%array_safe_set"
@@ -38,6 +40,11 @@ let max_length = Sys.max_array_length
 let create ~len x =
   try create len x with
   | Invalid_argument _ -> invalid_argf "Array.create ~len:%d: invalid length" len ()
+;;
+
+let create_float_uninitialized len =
+  try create_float_uninitialized len with
+  | Invalid_argument _ -> invalid_argf "Array.create_float_uninitialized ~len:%d: invalid length" len ()
 ;;
 
 let append = Caml.Array.append


### PR DESCRIPTION
The standard library provides `Array.create_float`, though it does not appear re-exported in `Base`.

This is *substantially* faster than creating a float array using `Base`'s `Array.create ~len 0.`, and also gives you the option of initializing it by yielding periodically to, say, `Async`. This is very important for low-latency, realtime applications as it prevents `Async` from being blocked.

This PR proposes exposing the stdlib `create_float` function, but with a more appropriate name: `create_float_uninitialized`.

A quick benchmark follows:

```ocaml
open! Base
open Stdlib.Printf

let timeit ~name ~times ~f =
  let t1 = Unix.gettimeofday () in
  for _i=0 to Int.pred times; do
    f ();
  done;
  let t2 = Unix.gettimeofday () in
  printf "[%s] x%d = %fs\n" name times (t2 -. t1)

let () =
  let len = 1000000 in
  let timeit = timeit ~times:1000 in
  timeit ~name:(sprintf "Array.create ~len:%d 0." len)
    ~f:(fun () ->
    let a = Array.create ~len 0. in
    a.(0) <- 1.0);

  timeit ~name:(sprintf "Array.create_float_uninitialized %d" len) ~f:(fun () ->
    let a = Array.create_float_uninitialized len in
    a.(0) <- 1.0)
```

```zsh
% dune exec ./test_base.exe
[Array.create ~len:1000000 0.] x1000 = 1.549169s
[Array.create_float_uninitialized 1000000] x1000 = 0.085484s
```