### PR TITLE
Extend `Monad` for folding over lists

### DIFF
--- a/base.opam
+++ b/base.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.10.0"}
-  "sexplib0"
+  "sexplib0" {>= "v0.15.0"}
   "dune"              {>= "2.0.0"}
   "dune-configurator"
 ]

--- a/src/dune
+++ b/src/dune
@@ -9,6 +9,7 @@
 
 (library (name base) (public_name base)
  (libraries base_internalhash_types caml sexplib0 shadow_stdlib)
+ (flags :standard -w -55)
  (c_flags :standard -D_LARGEFILE64_SOURCE (:include mpopcnt.sexp))
  (c_names exn_stubs int_math_stubs hash_stubs am_testing)
  (preprocess no_preprocessing)

--- a/src/list.ml
+++ b/src/list.ml
@@ -763,6 +763,7 @@ module Cartesian_product = struct
   let all_unit = Monad.all_unit
   let ignore_m = Monad.ignore_m
   let join = Monad.join
+  let fold_list = Monad.fold_list
 
   module Monad_infix = struct
     let ( >>| ) = ( >>| )

--- a/src/list.ml
+++ b/src/list.ml
@@ -764,6 +764,7 @@ module Cartesian_product = struct
   let ignore_m = Monad.ignore_m
   let join = Monad.join
   let fold_list = Monad.fold_list
+  let map_list = Monad.map_list
 
   module Monad_infix = struct
     let ( >>| ) = ( >>| )

--- a/src/monad.ml
+++ b/src/monad.ml
@@ -74,6 +74,13 @@ module Make_general (M : Basic_general) = struct
     in
     loop init
 
+  let map_list ~f =
+    let rec loop vs = function
+      | [] -> return (List.rev vs)
+      | t :: ts -> f t >>= fun v -> loop (v :: vs) ts
+    in
+    loop []
+
 end
 
 module Make_indexed (M : Basic_indexed) :

--- a/src/monad.ml
+++ b/src/monad.ml
@@ -66,6 +66,14 @@ module Make_general (M : Basic_general) = struct
     | [] -> return ()
     | t :: ts -> t >>= fun () -> all_unit ts
   ;;
+
+  let fold_list ~f ~init =
+    let rec loop acc = function
+      | [] -> return acc
+      | t :: ts -> f acc t >>= fun acc -> loop acc ts
+    in
+    loop init
+
 end
 
 module Make_indexed (M : Basic_indexed) :

--- a/src/monad_intf.ml
+++ b/src/monad_intf.ml
@@ -89,6 +89,10 @@ module type S_without_syntax = sig
   (** Like [all], but ensures that every monadic value in the list produces a unit value,
       all of which are discarded rather than being collected into a list. *)
   val all_unit : unit t list -> unit t
+
+  (** [fold_list ~f ~init [v1; ...; vn]] folds over a list applying a monadic operation,
+      i.e., performs [f init v1 >>= fun acc -> f acc v2 >>= ... >>= fun acc -> f acc vn]. *)
+  val fold_list : f:('a -> 'b -> 'a t) -> init:'a -> 'b list -> 'a t
 end
 
 module type S = sig
@@ -156,6 +160,7 @@ module type S2 = sig
   val ignore_m : (_, 'e) t -> (unit, 'e) t
   val all : ('a, 'e) t list -> ('a list, 'e) t
   val all_unit : (unit, 'e) t list -> (unit, 'e) t
+  val fold_list : f:('a -> 'b -> ('a, 'e) t) -> init:'a -> 'b list -> ('a, 'e) t
 end
 
 module type Basic3 = sig
@@ -218,6 +223,7 @@ module type S3 = sig
   val ignore_m : (_, 'd, 'e) t -> (unit, 'd, 'e) t
   val all : ('a, 'd, 'e) t list -> ('a list, 'd, 'e) t
   val all_unit : (unit, 'd, 'e) t list -> (unit, 'd, 'e) t
+  val fold_list : f:('a -> 'b -> ('a, 'd, 'e) t) -> init:'a -> 'b list -> ('a, 'd, 'e) t
 end
 
 module type Basic_indexed = sig
@@ -299,6 +305,7 @@ module type S_indexed = sig
   val ignore_m : (_, 'i, 'j) t -> (unit, 'i, 'j) t
   val all : ('a, 'i, 'i) t list -> ('a list, 'i, 'i) t
   val all_unit : (unit, 'i, 'i) t list -> (unit, 'i, 'i) t
+  val fold_list : f:('a -> 'b -> ('a, 'i, 'i) t) -> init:'a -> 'b list -> ('a, 'i, 'i) t
 end
 
 module S_to_S2 (X : S) : S2 with type ('a, 'e) t = 'a X.t = struct

--- a/src/monad_intf.ml
+++ b/src/monad_intf.ml
@@ -93,6 +93,10 @@ module type S_without_syntax = sig
   (** [fold_list ~f ~init [v1; ...; vn]] folds over a list applying a monadic operation,
       i.e., performs [f init v1 >>= fun acc -> f acc v2 >>= ... >>= fun acc -> f acc vn]. *)
   val fold_list : f:('a -> 'b -> 'a t) -> init:'a -> 'b list -> 'a t
+
+  (** [map_list ~f [v1; ...; vn]] applies a monadic operation to each element of a list,
+      i.e., performs [f v1 >>= fun w1 -> f v2 >>= fun w2 -> ... f vn >>= fun wn -> return [w1; ...; wn]]. *)
+  val map_list : f:('a -> 'b t) -> 'a list -> 'b list t
 end
 
 module type S = sig
@@ -161,6 +165,7 @@ module type S2 = sig
   val all : ('a, 'e) t list -> ('a list, 'e) t
   val all_unit : (unit, 'e) t list -> (unit, 'e) t
   val fold_list : f:('a -> 'b -> ('a, 'e) t) -> init:'a -> 'b list -> ('a, 'e) t
+  val map_list : f:('a -> ('b, 'e) t) -> 'a list -> ('b list, 'e) t
 end
 
 module type Basic3 = sig
@@ -224,6 +229,7 @@ module type S3 = sig
   val all : ('a, 'd, 'e) t list -> ('a list, 'd, 'e) t
   val all_unit : (unit, 'd, 'e) t list -> (unit, 'd, 'e) t
   val fold_list : f:('a -> 'b -> ('a, 'd, 'e) t) -> init:'a -> 'b list -> ('a, 'd, 'e) t
+  val map_list : f:('a -> ('b, 'd, 'e) t) -> 'a list -> ('b list, 'd, 'e) t
 end
 
 module type Basic_indexed = sig
@@ -306,6 +312,7 @@ module type S_indexed = sig
   val all : ('a, 'i, 'i) t list -> ('a list, 'i, 'i) t
   val all_unit : (unit, 'i, 'i) t list -> (unit, 'i, 'i) t
   val fold_list : f:('a -> 'b -> ('a, 'i, 'i) t) -> init:'a -> 'b list -> ('a, 'i, 'i) t
+  val map_list : f:('a -> ('b, 'i, 'i) t) -> 'a list -> ('b list, 'i, 'i) t
 end
 
 module S_to_S2 (X : S) : S2 with type ('a, 'e) t = 'a X.t = struct


### PR DESCRIPTION
The present PR suggests adding the following two values to `Base.Monad.S`:

```ocaml
val fold_list : f:('a -> 'b -> 'a t) -> init:'a -> 'b list -> 'a t

val map_list : f:('a -> 'b t) -> 'a list -> 'b list t
```

This will provide implementations of the functions above for modules that implement `Monad.Basic` such as `Option` or `Result`.

The function `fold_list` roughly corresponds to Haskell’s `foldM` of `Control.Monad` and `map_list` to `mapM` (though they do not generalize `list` to any type constructor of class `Foldable` as `foldM` and `mapM` do). As a special case, the newly introduced `Result.fold_list` corresponds to `List.fold_result`.

I would appreciate it if you could give any comment or suggestion.

(* PS: I couldn’t guess how to run tests and thereby don’t extend them so far. The following procedure seems promising, but it causes conflicts during the build:

1. Add `(inline_tests)` to `test/dune`,
2. Remove `sexp_grammar` from `test/dune`,
3. Invoke `opam pin add base .` at the repository,
4. Install necessary dependencies, i.e., `core v0.15.0` and `expect_test_helpers_core`, and
5. Invoke `dune test`.

```console
$ dune test                            
Error: Conflict between the following libraries:
- "base" in _build/default/src
- "base" in $HOME/.opam/4.12.0/lib/base
  -> required by library "core.base_for_tests" in
     $HOME/.opam/4.12.0/lib/core/base_for_tests
Error: Conflict between the following libraries:
- "base" in _build/default/src
- "base" in $HOME/.opam/4.12.0/lib/base
  -> required by library "ppx_compare.runtime-lib" in
     $HOME/.opam/4.12.0/lib/ppx_compare/runtime-lib
```

*)