### PR TITLE
Added Float.log2

### DIFF
--- a/src/float.mli
+++ b/src/float.mli
@@ -471,6 +471,10 @@ val frexp : t -> t * int
 external log10 : t -> t = "caml_log10_float" "log10"
 [@@unboxed] [@@noalloc]
 
+(** Base 2 logarithm. *)
+external log2 : t -> t = "caml_log2_float" "log2"
+[@@unboxed] [@@noalloc]
+
 (** [expm1 x] computes [exp x -. 1.0], giving numerically-accurate results even if [x] is
     close to [0.0]. *)
 external expm1 : t -> t = "caml_expm1_float" "caml_expm1"

--- a/src/float0.ml
+++ b/src/float0.ml
@@ -30,6 +30,8 @@ let ( %. ) a b =
   if m < 0. then m +. b else m
 ;;
 
+external log2 : float -> float = "caml_log2_float" "log2" [@@unboxed] [@@noalloc]
+
 (* The bits of INRIA's [Pervasives] that we just want to expose in [Float]. Most are
    already deprecated in [Pervasives], and eventually all of them should be. *)
 include (


### PR DESCRIPTION
This adds `Float.log2`, base 2 logarithm.

OCaml stdlib Float.log2 says it's available since 4.13.

I added the function to Float0.ml outside of the Stdlib section since I think contrary to other functions there, looks like log2 is not in Pervasives.