### PR TITLE
Add remove_duplicates function to the List module. 

### DIFF
--- a/src/list.ml
+++ b/src/list.ml
@@ -38,9 +38,7 @@ module Or_unequal_lengths = struct
     'a.
     (('a[@ocaml.local]) -> ('a[@ocaml.local]) -> int)
     -> ('a t[@ocaml.local])
-    -> ('a t[@ocaml.local])
-    -> int
-    =
+    -> ('a t[@ocaml.lo=
     fun _cmp__a a__014_ b__015_ ->
     if Stdlib.( == ) a__014_ b__015_
     then 0
@@ -1651,4 +1649,16 @@ let is_suffix list ~suffix ~equal:((equal_elt : _ -> _ -> _) [@local]) =
   let suffix_len = length suffix in
   list_len >= suffix_len
   && equal_with_local_closure equal_elt (drop list (list_len - suffix_len)) suffix
+;;
+
+(** returns lists without any duplicates and preserves the order of the original list *)
+let remove_duplicates l ~equal:equal_elt =
+  let rec aux l accum =
+    match l with
+    | [] -> List.rev accum
+    | h :: t ->
+        if mem accum h ~equal:equal_elt then aux t accum
+        else aux t (h :: accum)
+  in
+  aux l []
 ;;

--- a/src/list.mli
+++ b/src/list.mli
@@ -544,3 +544,7 @@ val transpose_exn : 'a t t -> 'a t t
 (** [intersperse xs ~sep] places [sep] between adjacent elements of [xs].  For example,
     [intersperse [1;2;3] ~sep:0 = [1;0;2;0;3]]. *)
 val intersperse : 'a t -> sep:'a -> 'a t
+
+(** [remove_duplicates l ~equal] removes any duplicate elements from [l] while preserving the order.
+    For example, remove_duplicates [1;1;2;1;3;4;3] ~equal:Int.equal = [1;2;3;4]. *)
+val remove_duplicates : 'a t -> equal:('a -> 'a -> bool) -> 'a t

--- a/src/list.mli
+++ b/src/list.mli
@@ -546,5 +546,5 @@ val transpose_exn : 'a t t -> 'a t t
 val intersperse : 'a t -> sep:'a -> 'a t
 
 (** [remove_duplicates l ~equal] removes any duplicate elements from [l] while preserving the order.
-    For example, remove_duplicates [1;1;2;1;3;4;3] ~equal:Int.equal = [1;2;3;4]. *)
+    For example, remove_duplicates [1;1;2;3;1;3;4;3] ~equal:Int.equal = [1;2;3;4]. *)
 val remove_duplicates : 'a t -> equal:('a -> 'a -> bool) -> 'a t


### PR DESCRIPTION
Notice the list module had a lot of functions for lists with duplicates in them such as contains_dup, find_dup, and remove_consecutive_duplicates. However, there is no function that removes_duplicates all together from what I have seen in the list module. So, I added one with a simple implementation.The first commit wasn't signed off using my real name by accident to I made a second commit message signed off with my real name.