### PR TITLE
Fix Windows compilation failure `ppx_base` because of `base` and `ocaml_intrinsics_kernel` symbol clash

### DIFF
--- a/src/int_math_stubs.c
+++ b/src/int_math_stubs.c
@@ -194,8 +194,3 @@ intnat Base_int_math_nativeint_ctz_unboxed(intnat v) {
 CAMLprim value Base_int_math_nativeint_ctz(value v) {
   return Val_int(Base_int_math_nativeint_ctz_unboxed(Nativeint_val(v)));
 }
-
-CAMLprim CAMLweakdef value caml_csel_value(value v_cond, value v_true,
-                                           value v_false) {
-  return (Bool_val(v_cond) ? v_true : v_false);
-}


### PR DESCRIPTION
Put `CAMLweakdef` function in its own translation unit for Windows compatibility, or it conflicts with other non-weakdef symbols with the same name from other libraries. There's a conflicting symbol in `ocaml_intrinsics_kernel` at: https://github.com/janestreet/ocaml_intrinsics_kernel/blob/1047d3186d0c6b498f1baa96024901cc3cbc2a19/src/conditional_stubs.c#L23-L26.

```console
$ dune build
File "bin/dune", line 3, characters 8-12:
3 |  (names main)
            ^^^^
/usr/lib/gcc/x86_64-w64-mingw32/11/../../../../x86_64-w64-mingw32/bin/ld: C:\Users\Antonin\AppData\Local\opam\default\lib\ocaml_intrinsics_kernel\libocaml_intrinsics_kernel_stubs.a(conditional_stubs.o):/cygdrive/c/Users/Antonin/AppData/Local/opam/default/.opam-switch/build/ocaml_intrinsics_kernel.v0.17.0/_build/default/src/conditional_stubs.c:16: multiple definition of `caml_csel_value'; C:\Users\Antonin\AppData\Local\opam\default\lib\base\libbase_stubs.a(int_math_stubs.o):/cygdrive/c/Users/Antonin/AppData/Local/opam/default/.opam-switch/build/base.v0.17.0/_build/default/src/int_math_stubs.c:200: first defined here
collect2: error: ld returned 1 exit status
** Fatal error: Error during linking
```

Also note that the `caml_` prefix for C symbols is reserved by the OCaml runtime. I suggest JS libraries pick another prefix.