### PR TITLE
Use Printtyp.Compat.signature after Format_doc change

### DIFF
--- a/base.opam
+++ b/base.opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "5.1.0"}
+  "ocaml" {>= "5.3.0"}
   "ocaml_intrinsics_kernel"
   "sexplib0"
   "dune"                    {>= "3.11.0"}

--- a/shadow-stdlib/gen/gen.ml
+++ b/shadow-stdlib/gen/gen.ml
@@ -19,7 +19,7 @@ let () =
     let pp = Format.formatter_of_buffer buf in
     Format.pp_set_margin pp max_int;
     (* so we can parse line by line below *)
-    Format.fprintf pp "%a@." Printtyp.signature cmi.Cmi_format.cmi_sign;
+    Format.fprintf pp "%a@." Printtyp.Compat.signature cmi.Cmi_format.cmi_sign;
     let s = Buffer.contents buf in
     let lines = Str.split (Str.regexp "\n") s in
     Printf.fprintf oc "[@@@warning \"-3\"]\n\n";


### PR DESCRIPTION
ocaml/ocaml#13169 added a document type for error messages and this change makes base compatible with OCaml trunk. 

I'm not sure how `base` compatibility with OCaml versions is managed, but I just wanted to notify the team an upcoming breakage (with the next release of OCaml) that I noticed via the [Sandmark benchmark builds](https://github.com/ocaml-bench/sandmark-nightly/commit/197c9bd869342121d65d2fa552c682017cb1b49a#diff-c635461b488c1e7d7b7feaf5fcb01945d54f84c512cf4db7e2dc390a2a23c5e8R456-R476). 