### PR TITLE
Align `ocaml-base-compiler` version.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,14 +17,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         ocaml:
-          - ocaml-base-compiler.5.0.0~alpha0
-          - 4.14.0
-        include:
-          - {os: ubuntu-latest, ocaml: 4.13.1}
-          - {os: ubuntu-latest, ocaml: 4.12.1}
-          - {os: ubuntu-latest, ocaml: 4.11.2}
-        exclude:
-          - {os: windows-latest, ocaml: ocaml-base-compiler.5.0.0~alpha0}
+          - ocaml-base-compiler.5.1.0
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,16 +17,19 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         ocaml:
-          - ocaml-base-compiler.5.1.0
+          - 5
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+            ref: ${{ github.event.pull_request.head.ref }}
+            repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Setup OCaml ${{ matrix.ocaml }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           cache-prefix: v1-${{ matrix.os }}-${{ matrix.ocaml }}
           dune-cache: true


### PR DESCRIPTION
## Problem

`ocaml-base-compiler` version was updated in https://github.com/janestreet/base/commit/21579b5903c81be975591b0a9f12699be8380594. Since then, it looks like the [github builds](https://github.com/janestreet/base/actions/workflows/workflow.yml) have been failing with

```
  [ERROR] No solution for base:   * No agreement on the version of ocaml-base-compiler:
              - (invariant) → ocaml-base-compiler = 4.14.0
              - base → ocaml >= 5.1.0 → ocaml-base-compiler >= 5.1.0~
              You can temporarily relax the switch invariant with `--update-invariant'
            * Missing dependency:
              - base → ocaml >= 5.1.0 → ocaml-variants >= 5.1.0~ → system-msvc
              unmet availability conditions: 'os = "win32"'
```

## Solution

Update the ocaml version to 5.
As a drive-by, updating the `setup-ocaml` gh action version to v3, since v2 did not support windows os for ocaml 5.
Another drive-by is updating the `checkout` action version, to keep this workflow up-to-date.