### PR TITLE
Remove dependency on bash

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -49,4 +49,4 @@
  (targets ocamlopt-flags)
  (deps)
  (action
-  (bash "echo '()' > ocamlopt-flags")))
+  (with-stdout-to ocamlopt-flags (echo "()"))))


### PR DESCRIPTION
This PR removes the dependency on `bash`, which affects the ability to compile on OpenBSD and Windows where `bash` is not available by default.

This fix was suggested by @polytypic.