### PR TITLE
fix -mpopcnt compilation failure on macOS/aarch64 10.4

### DIFF
--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -14,7 +14,11 @@ let () =
   main
     ~name:"discover"
     ~args:[ "-o", Set_string output, "FILENAME output file" ]
-    (fun c ->
-      let has_popcnt = c_test c ~c_flags:[ "-mpopcnt" ] program in
+    (fun _c ->
+      let f,oc = Filename.open_temp_file "baseconf" ".c" in
+      let has_popcnt =
+        Fun.protect ~finally:(fun () -> close_out oc; Sys.remove f)
+          (fun () -> Out_channel.(output_string oc program; flush oc);
+            Sys.command (Printf.sprintf "cc %s -mpopcnt -o /dev/null >/dev/null 2>&1" f) = 0) in
       Flags.write_sexp !output (if has_popcnt then [ "-mpopcnt" ] else []))
 ;;


### PR DESCRIPTION
The problem arises from this bug in clang
https://github.com/llvm/llvm-project/issues/116278 which causes the following:

```
$ cc t.c -mpopcnt
clang: error: unsupported option '-mpopcnt' for target 'arm64-apple-darwin24.4.0'
$ cc t.c -mpopcnt -lpthread
```

The src/discover uses dune configurator, which always appends the C link flags from ocamlopt to the command line, and so the configurator erronously thinks that -mpopcnt will work.

Since the dune configurator can't easily be overridden, this PR works around this specific link order issue by hand-calling the cc compiler from the discover binary.

fixes janestreet/base#164 and janestreet/base#168