### PR TITLE
Pass -c when testing for -mpopcnt in discover.ml

### DIFF
--- a/src/discover/discover.ml
+++ b/src/discover/discover.ml
@@ -25,7 +25,7 @@ let () =
             Out_channel.(
               output_string oc program;
               flush oc);
-            Sys.command (Printf.sprintf "cc %s -mpopcnt -o /dev/null >/dev/null 2>&1" f)
+            Sys.command (Printf.sprintf "cc %s -mpopcnt -c -o /dev/null >/dev/null 2>&1" f)
             = 0)
       in
       Flags.write_sexp !output (if has_popcnt then [ "-mpopcnt" ] else []))


### PR DESCRIPTION
For reasons I'm yet to understand, compiling _and linking_ the test program with -mpopcnt does not produce an error when running within the context of a homebrew package build, at least on macOS 15.6 aarch64. However just compiling the test program fails in the expected way.

The discover.ml program compiles and links the test c program, and consequently the generated mpopcnt.sexp containing "(-mpopcnt)". This of course causes build failures later on when -mpopcnt is passed along with -c.

Outside of the brew build context, compiling and linking with -mpopcnt failes in the expected way, so this is likely something to do with homebrew's cc shim. I've openned
https://github.com/Homebrew/brew/issues/21112, however in the meantime we can work around the issue by passing -c when testing for support for -mpopcnt.