### PR TITLE
Map print_endline to Stdlib instead of Stdio

### DIFF
--- a/shadow-stdlib/gen/mapper.mll
+++ b/shadow-stdlib/gen/mapper.mll
@@ -201,7 +201,7 @@ let val_replacement = function
   | "prerr_string"        -> Repl "Stdio.Out_channel.output_string Stdio.stderr"
   | "print_bytes"         -> Repl "Stdio.Out_channel.output_bytes Stdio.stdout"
   | "print_char"          -> Repl "Stdio.Out_channel.output_char Stdio.stdout"
-  | "print_endline"       -> Repl "Stdio.print_endline"
+  | "print_endline"       -> Repl "Stdlib.print_endline"
   | "print_float"         -> Repl "Stdio.eprintf \"%f\""
   | "print_int"           -> Repl "Stdio.eprintf \"%d\""
   | "print_newline"       -> Repl "Stdio.eprintf \"\n%!\""


### PR DESCRIPTION
Hey 👋 

I was trying to use `print_endline` and got the following warning

<img width="717" height="145" alt="image" src="https://github.com/user-attachments/assets/61fb15f8-3a0c-45e6-8de6-7c9280970a5d" />

However, `print_endline` seems to be exposed on `Stdlib` instead

<img width="489" height="131" alt="image" src="https://github.com/user-attachments/assets/9fe695be-0719-4cce-b05b-63a9c6fe76da" />

<img width="489" height="131" alt="image" src="https://github.com/user-attachments/assets/fec02c44-2ec8-447b-9ad4-428f7be41456" />

I changed the reference in the mapping, but I am not sure this is the correct fix. Is `print_endline` in fact supposed to be exposed by Stdio?