### PR TITLE
Fix CI compiler matrix

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,26 +16,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        ocaml:
-          - ocaml-base-compiler.5.0.0~alpha0
-          - 4.14.0
-        include:
-          - {os: ubuntu-latest, ocaml: 4.13.1}
-          - {os: ubuntu-latest, ocaml: 4.12.1}
-          - {os: ubuntu-latest, ocaml: 4.11.2}
-        exclude:
-          - {os: windows-latest, ocaml: ocaml-base-compiler.5.0.0~alpha0}
+        ocaml: ["5"]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup OCaml ${{ matrix.ocaml }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
-          cache-prefix: v1-${{ matrix.os }}-${{ matrix.ocaml }}
           dune-cache: true
           ocaml-compiler: ${{ matrix.ocaml }}
 


### PR DESCRIPTION
## Summary
- replace the obsolete OCaml 5.0 alpha and 4.x matrix with the supported OCaml 5 range
- retain Linux, macOS, and Windows coverage while allowing setup-ocaml to select the latest compatible OCaml 5 compiler
- update checkout and setup-ocaml to their current major versions and remove the retired cache-prefix input

## Context
`base.opam` now requires OCaml >= 5.1.0, while the existing matrix still includes an OCaml 5.0 prerelease and OCaml 4.x compilers. The scheduled workflow currently stops during action setup before reaching dependency installation.

With this update, fork CI initializes OCaml 5.4.1 and reaches `opam install . --deps-only --with-test` on Linux, macOS, and Windows. Current `master` still depends on unpublished packages such as `base_internalhash_types`, so the public workflow cannot complete dependency resolution until those packages are published.

Addresses #192.

## Validation
- `git diff --check`
- parsed `.github/workflows/workflow.yml` with Ruby YAML
- fork GitHub Actions run reached dependency installation on Linux, macOS, and Windows