### PR TITLE
Fix native build failures on released v0.17.3

### DIFF
--- a/src/applicative_intf.ml
+++ b/src/applicative_intf.ml
@@ -480,6 +480,7 @@ module type Applicative = sig
     end)
     (Impl : Intf.S) :
     Let_syntax with type 'a t := 'a X.t with module Open_on_rhs_intf := Intf
+  [@@warning "-67"]
 
   module Make_let_syntax2
     (X : For_let_syntax2) (Intf : sig
@@ -487,6 +488,7 @@ module type Applicative = sig
     end)
     (Impl : Intf.S) :
     Let_syntax2 with type ('a, 'e) t := ('a, 'e) X.t with module Open_on_rhs_intf := Intf
+  [@@warning "-67"]
 
   module Make_let_syntax3
     (X : For_let_syntax3) (Intf : sig
@@ -496,6 +498,7 @@ module type Applicative = sig
     Let_syntax3
       with type ('a, 'd, 'e) t := ('a, 'd, 'e) X.t
       with module Open_on_rhs_intf := Intf
+  [@@warning "-67"]
 
   module Make_using_map2 (X : Basic_using_map2) : S with type 'a t := 'a X.t
 

--- a/src/array.ml
+++ b/src/array.ml
@@ -396,7 +396,7 @@ let[@inline always] extremal_element t ~compare ~keep_left_if =
     let result = ref (unsafe_get t 0) in
     for i = 1 to length t - 1 do
       let x = unsafe_get t i in
-      result := Bool.select ((keep_left_if [@inlined]) (compare x !result)) x !result
+      result := Bool.select ((keep_left_if [@inlined hint]) (compare x !result)) x !result
     done;
     Some !result)
 ;;

--- a/src/blit_intf.ml
+++ b/src/blit_intf.ml
@@ -163,6 +163,7 @@ module type Blit = sig
   end)
   (To_bytes : S_distinct with type src := T.t with type dst := bytes) :
     S_to_string with type t := T.t
+  [@@warning "-67"]
 
   (** [Make1] is for blitting between two values of the same polymorphic type. *)
   module Make1 (Sequence : Sequence1) : S1 with type 'a t := 'a Sequence.t

--- a/src/float.ml
+++ b/src/float.ml
@@ -929,7 +929,7 @@ let ieee_exponent t =
 let ieee_mantissa t =
   let bits = Stdlib.Int64.bits_of_float t in
   (* This is safe because mantissa_mask64 < Int63.max_value *)
-  (Int63.of_int64_trunc [@inlined]) Stdlib.Int64.(logand bits mantissa_mask64)
+  Int63.of_int64_trunc Stdlib.Int64.(logand bits mantissa_mask64)
 ;;
 
 let create_ieee_exn ~negative ~exponent ~mantissa =


### PR DESCRIPTION
v0.17.3 doesn't build from a clean opam switch: native compilation never reaches base.cmxa. Two unrelated warnings are fatal under the flags dune derives from (lang dune 3.11), and the first hides the second.

Warning 67 (unused-functor-parameter) at blit_intf.ml:164 and applicative_intf.ml:481,488,495. The functor parameters are only reached through destructive substitution, so the names really are unused and the code is correct as written. Annotated with [@warning "-67"] to keep the pattern.

Warning 55 (inlining-impossible) at float.ml:932 and array.ml:399, only visible once 67 is out of the way. In float.ml the application is unresolvable on every backend, so the [@inlined] never did anything and is removed. In array.ml flambda does resolve it (it inlines extremal_element first), so the hint is kept but weakened to [@inlined hint], ignored rather than fatal where it can't be honored. A scoped [@warning "-55"] isn't possible here since 55 comes from the middle-end after the typechecker's warning scopes are gone.

No library-wide warning flags changed. Verified on OCaml 5.2.0 (with and without flambda) and 5.1.0 (base.opam's lower bound), dune 3.24.0, dune build src/ clean on all three.

Based on v0.17.3 and targeted at the v0.17 branch; the change is four self-contained files.